### PR TITLE
Fixes Inf.Duration = 0 returning error message.

### DIFF
--- a/hls/encode-util.go
+++ b/hls/encode-util.go
@@ -49,10 +49,7 @@ func writeIndependentSegment(isIndSeg bool, buf *manifest.BufWrapper) {
 //writeStartPoint sets the #EXT-X-START tag on Media and Master Playlist file
 func writeStartPoint(sp *StartPoint, buf *manifest.BufWrapper) {
 	if sp != nil {
-		if !buf.WriteValidString(sp.TimeOffset, fmt.Sprintf("#EXT-X-START:TIME-OFFSET=%s", strconv.FormatFloat(sp.TimeOffset, 'f', 3, 32))) {
-			buf.Err = attributeNotSetError("EXT-X-START", "TIME-OFFSET")
-			return
-		}
+		buf.WriteString(fmt.Sprintf("#EXT-X-START:TIME-OFFSET=%s", strconv.FormatFloat(sp.TimeOffset, 'f', 3, 32)))
 		buf.WriteValidString(sp.Precise, ",PRECISE=YES")
 		buf.WriteRune('\n')
 	}
@@ -234,10 +231,11 @@ func (s *Segment) writeSegmentTags(buf *manifest.BufWrapper) {
 			return
 		}
 
-		if s.Inf == nil || !buf.WriteValidString(s.Inf.Duration, fmt.Sprintf("#EXTINF:%s,%s\n", strconv.FormatFloat(s.Inf.Duration, 'f', 3, 32), s.Inf.Title)) {
+		if s.Inf == nil {
 			buf.Err = attributeNotSetError("EXTINF", "DURATION")
 			return
 		}
+		buf.WriteString(fmt.Sprintf("#EXTINF:%s,%s\n", strconv.FormatFloat(s.Inf.Duration, 'f', 3, 32), s.Inf.Title))
 
 		if s.Byterange != nil {
 			buf.WriteString(fmt.Sprintf("#EXT-X-BYTERANGE:%s", strconv.FormatInt(s.Byterange.Length, 10)))

--- a/hls/encode-util_test.go
+++ b/hls/encode-util_test.go
@@ -228,6 +228,25 @@ func TestGenerateMediaPlaylist(t *testing.T) {
 	if strings.Contains(b.String(), "#EXT-X-I-FRAMES-ONLY") {
 		t.Error("Expected buf to not contain #EXT-X-I-FRAMES-ONLY")
 	}
+
+	p.Segments[0].Inf.Duration = 0
+	p.StartPoint.TimeOffset = 0
+
+	buf, err = p.Encode()
+	if err != nil {
+		t.Fatalf("Expected err to be nil, but got %s", err.Error())
+	}
+
+	b = new(bytes.Buffer)
+	b.ReadFrom(buf)
+
+	if !strings.Contains(b.String(), "#EXT-X-START:TIME-OFFSET=0.000") {
+		t.Error("Expected buf to contain #EXT-X-START")
+	}
+
+	if !strings.Contains(b.String(), "#EXTINF:0.000,") {
+		t.Error("Expected buf to contain #EXT-X-START")
+	}
 }
 
 func TestDateRange(t *testing.T) {


### PR DESCRIPTION
Fixes bug where Inf.Duration and StarPoint.TimeOffset couldn't be set to 0. 
According to HLS specs these values are allowed for both attributes and shouldn't return an error.