### PR TITLE
Move renditions off variant

### DIFF
--- a/hls/decode-util_test.go
+++ b/hls/decode-util_test.go
@@ -209,6 +209,7 @@ func TestReadMediaPlaylist(t *testing.T) {
 		},
 		ProgramDateTime: time.Now(),
 		Discontinuity:   true,
+		Map:             &Map{URI: "map2"},
 	}
 
 	p := NewMediaPlaylist(7)
@@ -249,7 +250,7 @@ func TestReadMediaPlaylist(t *testing.T) {
 		if s.URI != newP.Segments[i].URI {
 			t.Errorf("Expected URI to be %s, but got %s", s.URI, newP.Segments[i].URI)
 		}
-		if s.Map != nil && s.Map.URI != newP.Segments[i].Map.URI {
+		if !s.Map.Equal(newP.Segments[i].Map) {
 			t.Errorf("Expected %d Segment Map to be %v, but got %v", i, s.Map, newP.Segments[i].Map)
 		}
 		// if s.DateRange != nil && !reflect.DeepEqual(s.DateRange, newP.Segments[i].DateRange) {

--- a/hls/decode-util_test.go
+++ b/hls/decode-util_test.go
@@ -120,8 +120,8 @@ func TestReadMasterPlaylistFile(t *testing.T) {
 		t.Errorf("Expected Variants len 14, but got %d", len(p.Variants))
 	}
 
-	if len(p.Variants[0].Renditions) != 5 {
-		t.Errorf("Expected Renditions len 5, but got %d", len(p.Variants[0].Renditions))
+	if len(p.Renditions) != 5 {
+		t.Errorf("Expected Renditions len 5, but got %d", len(p.Renditions))
 	}
 
 	k := &Key{IsSession: true,

--- a/hls/encode-util.go
+++ b/hls/encode-util.go
@@ -452,12 +452,10 @@ func (p *MediaPlaylist) checkCompatibility(s *Segment) error {
 func (p *MasterPlaylist) checkCompatibility() error {
 	switch {
 	case p.Version < 7:
-		for _, variant := range p.Variants {
-			for _, rendition := range variant.Renditions {
-				if rendition.Type == cc {
-					if strings.HasPrefix(rendition.InstreamID, "SERVICE") {
-						return backwardsCompatibilityError(p.Version, "#EXT-X-MEDIA")
-					}
+		for _, rendition := range p.Renditions {
+			if rendition.Type == cc {
+				if strings.HasPrefix(rendition.InstreamID, "SERVICE") {
+					return backwardsCompatibilityError(p.Version, "#EXT-X-MEDIA")
 				}
 			}
 		}

--- a/hls/encode-util_test.go
+++ b/hls/encode-util_test.go
@@ -125,15 +125,6 @@ func TestGenerateMasterPlaylist(t *testing.T) {
 		Language: "English",
 		Default:  false,
 	}
-	variant := &Variant{
-		Renditions: []*Rendition{rend, rend2},
-		IsIframe:   false,
-		URI:        "http://test.com",
-		Bandwidth:  234000,
-		Resolution: "230x400",
-		Codecs:     "These codescs",
-	}
-
 	rend3 := &Rendition{
 		Type:     "VIDEO",
 		GroupID:  "Test",
@@ -141,15 +132,23 @@ func TestGenerateMasterPlaylist(t *testing.T) {
 		Language: "Portuguese",
 	}
 
-	variant2 := &Variant{
-		Renditions: []*Rendition{rend3},
+	variant := &Variant{
 		IsIframe:   false,
-		URI:        "thistest.com",
-		Bandwidth:  145000,
+		URI:        "http://test.com",
+		Bandwidth:  234000,
+		Resolution: "230x400",
+		Codecs:     "These codescs",
+	}
+
+	variant2 := &Variant{
+		IsIframe:  false,
+		URI:       "thistest.com",
+		Bandwidth: 145000,
 	}
 
 	p := NewMasterPlaylist(5)
 	p.Variants = append(p.Variants, variant, variant2)
+	p.Renditions = append(p.Renditions, rend, rend2, rend3)
 	p.SessionData = []*SessionData{&SessionData{DataID: "test", Value: "this is the session data"}}
 	p.SessionKeys = []*Key{&Key{IsSession: true, Method: "sample-aes", URI: "keyuri"}}
 	p.IndependentSegments = true

--- a/hls/types-master.go
+++ b/hls/types-master.go
@@ -7,10 +7,11 @@ import (
 
 //MasterPlaylist represents a Master Playlist and its tags
 type MasterPlaylist struct {
-	URI                 string     // Location of the master playlist
-	M3U                 bool       // Represents tag #EXTM3U. Indicates if present. MUST be present.
-	Version             int        // Represents tag #EXT-X-VERSION. MUST be present.
-	Variants            []*Variant // Represents the index playlists
+	URI                 string       // Location of the master playlist
+	M3U                 bool         // Represents tag #EXTM3U. Indicates if present. MUST be present.
+	Version             int          // Represents tag #EXT-X-VERSION. MUST be present.
+	Variants            []*Variant   // Represents the #EXT-X-I-FRAME-STREAM-INF and #EXT-X-STREAM-INF playlists
+	Renditions          []*Rendition // Represents the #EXT-X-MEDIA tags
 	SessionData         []*SessionData
 	SessionKeys         []*Key
 	IndependentSegments bool // Represents tag #EXT-X-INDEPENDENT-SEGMENTS. Applies to every Media Segment of every Media Playlist referenced. V6 or higher.
@@ -73,7 +74,6 @@ func (r *Rendition) Request() (*http.Request, error) {
 // #EXT-X-I-FRAME-STREAM-INF identifies Media Playlist file containing the I-frames of a multimedia presentation.
 // It supports the same parameters as EXT-X-STREAM-INF except Audio, Subtitles and ClosedCaptions.
 type Variant struct {
-	Renditions     []*Rendition
 	IsIframe       bool    //Identifies if #EXT-X-STREAM-INF or #EXT-X-I-FRAME-STREAM-INF
 	URI            string  //If #EXT-X-STREAM-INF, URI line MUST follow the tag. If #EXT-X-I-FRAME-STREAM-INF, URI MUST appear as an attribute of the tag.
 	ProgramID      int64   //Removed on Version 6

--- a/hls/types-segment.go
+++ b/hls/types-segment.go
@@ -63,6 +63,21 @@ type Byterange struct {
 	Offset *int64
 }
 
+// Equal determines if the two byterange objects are equal and contain the same values
+func (b *Byterange) Equal(other *Byterange) bool {
+	if b != nil && other != nil {
+		if b.Length != other.Length {
+			return false
+		}
+
+		if b.Offset != nil && other.Offset != nil {
+			return *b.Offset == *other.Offset
+		}
+	}
+
+	return b == other
+}
+
 // Key represents tags #EXT-X-KEY:<attribute=value> and #EXT-X-SESSION-KEY. Specifies how to decrypt an encrypted media segment.
 // #EXT-X-SESSION-KEY is exclusively a Master Playlist tag (HLS V7) and it SHOULD be used if multiple Variant Streams use the same encryption keys.
 // TODO(jstackhouse): Split SESSION-KEY into it's own type as it's got different validation properties, and is part of the master playlist, not media playlist.
@@ -97,6 +112,16 @@ type Map struct {
 	Byterange *Byterange //Optional. Indicates the byte range into the URI resource containing the Media Initialization Section.
 
 	mediaPlaylist *MediaPlaylist // MediaPlaylist is included to be used internally for resolving relative resource locations
+}
+
+// Equal determines if the two maps are equal, does not check private fields for equality so this does not guarantee that two maps will act identically.
+// Works on nil structures, if both m and other are nil, they are considered equal.
+func (m *Map) Equal(other *Map) bool {
+	if m != nil && other != nil {
+		return m.URI == other.URI && m.Byterange.Equal(other.Byterange)
+	}
+
+	return m == other
 }
 
 // Request creates a new http request ready to retrieve the segment


### PR DESCRIPTION
Renditions or #EXT-X-MEDIA are necessarily tied to the variant until they reference them via the group tag, so I moved the stored location onto the playlist they were part of.